### PR TITLE
The GOMC-dev software changed the output from outputting 2 GOMC dcd f…

### DIFF
--- a/combine_data_NAMD_GOMC.py
+++ b/combine_data_NAMD_GOMC.py
@@ -880,9 +880,8 @@ def combine_dcd_files(engine_name,
 
     # the combined final Engine dcd file
     if engine_name == 'GOMC':
-        # take only the last frame from GOMC as it ouputs the from 1 and the last frame
-        # we only want the last frame (i.e., -stride 2)
-        run_engine_dcdcat_box_x_command = "{} -o {}/{} -stride 2 {}/{}" \
+        # take only the last frame from GOMC.  Now GOMC only outputs the last frame so only need (i.e., -stride 1)
+        run_engine_dcdcat_box_x_command = "{} -o {}/{} -stride 1 {}/{}" \
                                                   "".format(str(rel_path_to_combine_binary_catdcd),
                                                             str(path_combined_data_folder),
                                                             engine_dcd_combined_name_str,


### PR DESCRIPTION
The GOMC-dev software changed the output from outputting 2 GOMC dcd frames per cycle (start and finish) to only 1 frame per cycle (only the final).  Therefore, the combiner file stride on the overall dcd frames changed from 2 to 1 to accommodate the GOMC-dev software change.
